### PR TITLE
Add simple logging utility for debugging

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import bodyParser from 'body-parser';
 import dotenv from 'dotenv';
 import rippleEngine from './rippleEngine';
 import chapters from './chapters';
+import { log } from './logger';
 
 dotenv.config();
 
@@ -15,7 +16,7 @@ app.use('/chapters', chapters);
 if (require.main === module) {
   const PORT = process.env.PORT || 3000;
   app.listen(Number(PORT), () => {
-    console.log(`Server running on port ${PORT}`);
+    log(`Server running on port ${PORT}`);
   });
 }
 

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,0 +1,7 @@
+export function log(...args: unknown[]): void {
+  console.log(new Date().toISOString(), '-', ...args);
+}
+
+export function error(...args: unknown[]): void {
+  console.error(new Date().toISOString(), '-', ...args);
+}

--- a/server/rippleEngine.ts
+++ b/server/rippleEngine.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from 'express';
+import { log, error } from './logger';
 
 const router = Router();
 
@@ -11,6 +12,7 @@ function getState(sessionId: string): RippleState {
   const now = Date.now();
   if (!states.has(sessionId)) {
     states.set(sessionId, { time: 0, amplitude: 1, lastAccess: now });
+    log('Created session', sessionId);
   }
   const state = states.get(sessionId)!;
   state.lastAccess = now;
@@ -22,6 +24,7 @@ setInterval(() => {
   for (const [key, state] of states) {
     if (now - state.lastAccess > ttl) {
       states.delete(key);
+      log('Session expired', key);
     }
   }
 }, 60_000);
@@ -30,6 +33,7 @@ router.get('/state', (req: Request, res: Response) => {
   const session = req.header('X-Session-Id') || 'default';
   const rippleState = getState(session);
   res.json(rippleState);
+  log('GET /ripple/state', session, rippleState);
 });
 
 router.post('/step', (req: Request, res: Response) => {
@@ -37,12 +41,14 @@ router.post('/step', (req: Request, res: Response) => {
   const rippleState = getState(session);
   const dt = Number(req.body.dt ?? 0.1);
   if (!Number.isFinite(dt) || dt <= 0) {
+    error('Invalid dt', dt, 'session', session);
     return res.status(400).json({ error: 'Invalid dt' });
   }
   const freq = Number(process.env.RIPPLE_FREQUENCY ?? 1);
   rippleState.time += dt;
   rippleState.amplitude = Math.cos(rippleState.time * freq);
   res.json(rippleState);
+  log('POST /ripple/step', session, dt, rippleState);
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- add timestamped logger utility
- use logger in Express server
- log session lifecycle and requests in ripple engine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846d2496dc4832fa68b5dd456a51d06