### PR TITLE
docs: align spellbooks with curriculum

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The tests cover the ripple engine and chapter routes.
 - **client/** – React components for the spellbook UI and ripple visualizer.
 - **server/** – API endpoints and a simple ripple engine for simulations.
 - **game-engine/** – Core physics and time navigation utilities.
-- **spellbooks/** – Chapters of spells and narrative content.
+- **spellbooks/** – Narrative chapters aligned with the [curriculum](docs/curriculum/README.md).
 - **docs/** – Research notes and glossary entries.
 - **symbol-cast-algorithms/** – Generalized data structures and algorithms for
   the Symbol Cast runtime in EtherOS. Inputs are visualized as 3D objects and
@@ -80,6 +80,9 @@ The tests cover the ripple engine and chapter routes.
   spatial dimension.
 
 The `quantum mechanics` folder contains the ongoing paper *Ripples in Spacetime and Quantum Branches*, which explores a polar coordinate approach to quantum wavefunctions. Source files are under `quantum mechanics/paper`.
+
+## Curriculum
+See [docs/curriculum](docs/curriculum/README.md) for a chapter-based roadmap.
 
 ## Contributing
 This project is experimental. Contributions that expand the spellbooks, improve the ripple engine, or elaborate on the research are welcome.

--- a/docs/curriculum/README.md
+++ b/docs/curriculum/README.md
@@ -1,0 +1,16 @@
+# Curriculum
+
+A high-level roadmap for the *Of Matter & Mana* project.
+Each chapter below links to a directory that outlines the lessons and topics to be covered.
+
+1. [Open Source Development for Wizards](open-source-development-for-wizards/README.md)
+2. [Spells: The Flow of Energy & Information](spells-flow-of-energy-information/README.md)
+3. [Data Structures & Algorithms](data-structures-algorithms/README.md)
+4. [Golems: Machine Learning](golems-machine-learning/README.md)
+5. [Sprites: LLM & AI](sprites-llm-ai/README.md)
+6. [Spirits: AGI](spirits-agi/README.md)
+7. [Casting Code](casting-code/README.md)
+8. [Symbolic Casting: Symbol cast & Q++](symbolic-casting/README.md)
+9. [Elemental Magic](elemental-magic/README.md)
+10. [Elemental Spells](elemental-spells/README.md)
+

--- a/docs/curriculum/casting-code/README.md
+++ b/docs/curriculum/casting-code/README.md
@@ -1,0 +1,32 @@
+# Casting Code
+
+## Core Techniques
+1. Arrays & Hashing
+2. Two Pointers
+3. Sliding Window
+4. Stack
+5. Binary Search
+6. Linked List
+7. Trees
+8. Heap / Priority Queue
+9. Backtracking
+10. Tries
+11. Graphs
+12. Advanced Graphs
+13. 1D Dynamic Programming
+14. 2D Dynamic Programming
+15. Greedy
+16. Intervals
+17. Math & Geometry
+18. Bit Manipulation
+
+### Arrays & Hashing Exercises
+1. **Contains Duplicates** – Determine if any value appears more than once.
+2. **Valid Anagram** – Check if two strings are anagrams of each other.
+3. **Two Sum** – Find indices `i` and `j` where `nums[i] + nums[j] = target`.
+4. **Group Anagrams** – Group strings that are anagrams.
+5. **Top K Frequent Elements** – Return the `k` most frequent values in an array.
+6. **Encode & Decode String** – Design an algorithm to encode and decode a list of strings.
+7. **Product of Array Except Self** – Return an array where each position is the product of all other values.
+8. **Longest Consecutive Sequence** – Find the length of the longest consecutive elements sequence.
+

--- a/docs/curriculum/data-structures-algorithms/README.md
+++ b/docs/curriculum/data-structures-algorithms/README.md
@@ -1,0 +1,30 @@
+# Data Structures & Algorithms
+
+## Lesson 2 – Casting with Data Structures & Algorithms
+- Exploring fundamental data structures
+- Implementing common algorithms
+
+## Lesson 2 – Crafting Data Structures & Algorithms
+- Designing efficient structures
+- Algorithmic optimization techniques
+
+### Core Topics
+1. Arrays & Hashmaps
+2. Two Pointers
+3. Sliding Window
+4. Stack
+5. Binary Search
+6. Linked List
+7. Trees
+8. Heap / Priority Queue
+9. Backtracking
+10. Tries
+11. Graphs
+12. Advanced Graphs
+13. 1D Dynamic Programming
+14. 2D Dynamic Programming
+15. Greedy
+16. Intervals
+17. Math & Geometry
+18. Bit Manipulation
+

--- a/docs/curriculum/elemental-magic/README.md
+++ b/docs/curriculum/elemental-magic/README.md
@@ -1,0 +1,22 @@
+# Elemental Magic
+
+## Introduction to Physics Simulators
+- Magic = manipulative geometric physics
+
+## Rune Mathematics
+- `curved_infinity = luck_mechanics.complex_math.curved_infinity`
+- `composite_level_graph = luck_mechanics.complex_math.composite_level_graph`
+
+## Luck Mechanics
+- `spacetime_ripples = luck_mechanics.spacetime_ripples`
+- `quantum_field_tension = luck_mechanics.quantum_field_tension`
+- `luck_cone = luck_mechanics.luck_cone`
+- `chance_feild = luck_mechanics.chance_feild`
+- `lucky_interfernce = luck_mechanics.lucky_interfernce`
+- `jinx_interfernce = luck_mechanics.jinx_interfernce`
+
+## W.AND.S
+- `quantum_simulator = luck_mechanics.wavefunction_computation.quantum_simulator`
+- `phase_compass = luck_mechanics.wavefunction_computation.phase_compass`
+- `spacetime_map = luck_mechanics.wavefunction_computation.spacetime_map`
+

--- a/docs/curriculum/elemental-spells/README.md
+++ b/docs/curriculum/elemental-spells/README.md
@@ -1,0 +1,29 @@
+# Elemental Spells
+
+## Spells of Luck
+- `spiderman_anchor_points = luck_mechanics.wavefunction_computation.spiderman_anchor_points`
+
+## Spells of Spacetime & Travel
+- `entanglement_acceleration_tension = luck_mechanics.wavefunction_computation.entanglement_acceleration_tension`
+
+## Spells of Teleportation
+- `wormhole_curvature = luck_mechanics.wavefunction_computation.wormhole_curvature`
+- `pocket_dim_geometry = luck_mechanics.wavefunction_comp_s.pocket_dim_geometrics`
+
+## Spells of Darkness
+- `black_hole_geometrics = luck_mechanics.wavefunction_comp_s.black_hole_geometrics`
+- `grey_hole_geometrics = luck_mechanics.wavefunction_comp_s.grey_hole_geometrics`
+
+## Spells of Light
+- `light_physics = luck_mechanics.wavefunction_computation.light_physics`
+- `white_hole_geometrics = luck_mechanics.wavefunction_comp_s.white_hole_geometrics`
+
+## Spells of Matter & Mass
+- `universe_energy_spread = luck_mechanics.wavefunction_comp_s.eneergy_spread`
+- `multiverse_energy_spread = luck_mechanics.wavefunction_comp_s.eneergy_spread`
+- `omniverse_energy_spread = luck_mechanics.wavefunction_comp_s.eneergy_spread`
+- `solid_energy_spread = luck_mechanics.wavefunction_comp_s.eneergy_spread`
+- `liquid_energy_spread = luck_mechanics.wavefunction_comp_s.eneergy_spread`
+- `gas_energy_spread = luck_mechanics.wavefunction_comp_s.eneergy_spread`
+- `plasma_energy_spread = luck_mechanics.wavefunction_comp_s.eneergy_spread`
+

--- a/docs/curriculum/golems-machine-learning/README.md
+++ b/docs/curriculum/golems-machine-learning/README.md
@@ -1,0 +1,10 @@
+# Golems: Machine Learning
+
+## Casting with Golems
+- Practical machine learning workflows
+- Training and evaluating models
+
+## Crafting Golems
+- Model architecture design
+- Data preprocessing & feature engineering
+

--- a/docs/curriculum/open-source-development-for-wizards/README.md
+++ b/docs/curriculum/open-source-development-for-wizards/README.md
@@ -1,0 +1,10 @@
+# Open Source Development for Wizards
+
+## Lesson 0 – Open Source Development for Wizards
+- Introduction to series
+- Creating a GitHub account
+- Creating a new repository
+- Setting up your code environment for Python
+- Setting up your coding environment for C++
+- Setting up your code environment for Q++
+

--- a/docs/curriculum/spells-flow-of-energy-information/README.md
+++ b/docs/curriculum/spells-flow-of-energy-information/README.md
@@ -1,0 +1,24 @@
+# Spells: The Flow of Energy & Information
+
+## Lesson 1 – Spell Casting: Controlling the Flow
+- Data & Information
+- Energy category: Ordered & Unordered
+- Input to Output: E(n) = Input(n) = Output(n)
+  - Simple case
+  - Normal case
+  - Invalid case
+  - Corner case
+- Process: E(n) = O(n) = S(n) + cT(n)
+  - Add Information: Input(0) = Output(1) – Inject
+  - Remove Information: Input(1) = Output(0) – Select
+  - Modify Information: Input(1) = Output(0.5) – Derive
+  - Transfer Information: Input(1) = Output(1) – Format
+- Approach: Input → process → output
+- Algorithm: Input → Preprocess → process → postprocess → output
+- Brute force vs. optimized
+- Pattern, redundancy & bottlenecks
+
+## Lesson 1 – Spell Crafting: Designing the Flow
+- Systems design
+- Design patterns
+

--- a/docs/curriculum/spirits-agi/README.md
+++ b/docs/curriculum/spirits-agi/README.md
@@ -1,0 +1,10 @@
+# Spirits: AGI
+
+## Casting with Spirits
+- Foundations of artificial general intelligence
+- Safety and alignment considerations
+
+## Crafting Spirits
+- Architectures for general intelligence
+- Ethical frameworks and governance
+

--- a/docs/curriculum/sprites-llm-ai/README.md
+++ b/docs/curriculum/sprites-llm-ai/README.md
@@ -1,0 +1,10 @@
+# Sprites: LLM & AI
+
+## Casting with Sprites
+- Prompt engineering and interaction patterns
+- Integrating LLMs into applications
+
+## Crafting Sprites
+- Fine-tuning and customizing language models
+- Responsible AI practices
+

--- a/docs/curriculum/symbolic-casting/README.md
+++ b/docs/curriculum/symbolic-casting/README.md
@@ -1,0 +1,5 @@
+# Symbolic Casting: Symbol cast & Q++
+
+- Symbol Cast concepts
+- Q++ language fundamentals
+

--- a/spellbooks/README.md
+++ b/spellbooks/README.md
@@ -1,0 +1,14 @@
+# Spellbooks
+
+Narrative guides aligned with the project curriculum. Each book corresponds to a chapter in the learning roadmap.
+
+1. [Open Source Development for Wizards](open-source-development-for-wizards/README.md)
+2. [Spells: The Flow of Energy & Information](spells-flow-of-energy-information/README.md)
+3. [Data Structures & Algorithms](data-structures-algorithms/README.md)
+4. [Golems: Machine Learning](golems-machine-learning/README.md)
+5. [Sprites: LLM & AI](sprites-llm-ai/README.md)
+6. [Spirits: AGI](spirits-agi/README.md)
+7. [Casting Code](casting-code/README.md)
+8. [Symbolic Casting: Symbol cast & Q++](symbolic-casting/README.md)
+9. [Elemental Magic](elemental-magic/README.md)
+10. [Elemental Spells](elemental-spells/README.md)

--- a/spellbooks/casting-code/README.md
+++ b/spellbooks/casting-code/README.md
@@ -1,0 +1,3 @@
+# Casting Code
+
+Spell patterns for solving algorithmic challenges. See the [curriculum](../../docs/curriculum/casting-code/README.md) for topics and exercises.

--- a/spellbooks/data-structures-algorithms/README.md
+++ b/spellbooks/data-structures-algorithms/README.md
@@ -1,0 +1,3 @@
+# Data Structures & Algorithms
+
+Build efficient constructs and reasoning charms. See the [curriculum](../../docs/curriculum/data-structures-algorithms/README.md) for the full study plan.

--- a/spellbooks/elemental-magic/README.md
+++ b/spellbooks/elemental-magic/README.md
@@ -1,0 +1,3 @@
+# Elemental Magic
+
+Physics simulators and rune mathematics for shaping matter. See the [curriculum](../../docs/curriculum/elemental-magic/README.md) for research notes.

--- a/spellbooks/elemental-spells/README.md
+++ b/spellbooks/elemental-spells/README.md
@@ -1,0 +1,3 @@
+# Elemental Spells
+
+Practical incantations of luck, spacetime, and matter. See the [curriculum](../../docs/curriculum/elemental-spells/README.md) for spell lists.

--- a/spellbooks/foundations/README.md
+++ b/spellbooks/foundations/README.md
@@ -1,3 +1,0 @@
-# Book I – Foundations
-
-Basic spells for manipulating matter and mana.

--- a/spellbooks/golems-machine-learning/README.md
+++ b/spellbooks/golems-machine-learning/README.md
@@ -1,0 +1,3 @@
+# Golems: Machine Learning
+
+Animate constructs with data-driven spirits. See the [curriculum](../../docs/curriculum/golems-machine-learning/README.md) for guides.

--- a/spellbooks/open-source-development-for-wizards/README.md
+++ b/spellbooks/open-source-development-for-wizards/README.md
@@ -1,0 +1,3 @@
+# Open Source Development for Wizards
+
+Set up repositories, environments, and collaboration spells. See the [curriculum](../../docs/curriculum/open-source-development-for-wizards/README.md) for detailed lessons.

--- a/spellbooks/paths/README.md
+++ b/spellbooks/paths/README.md
@@ -1,3 +1,0 @@
-# Book III – Paths
-
-World hopping and branching choices.

--- a/spellbooks/reflection/README.md
+++ b/spellbooks/reflection/README.md
@@ -1,3 +1,0 @@
-# Book II – Reflection
-
-Time loops, self-recursion, and echoes.

--- a/spellbooks/shadowlight/README.md
+++ b/spellbooks/shadowlight/README.md
@@ -1,3 +1,0 @@
-# Book V – Shadow & Light
-
-Legacy, paradox, and ethics.

--- a/spellbooks/spells-flow-of-energy-information/README.md
+++ b/spellbooks/spells-flow-of-energy-information/README.md
@@ -1,0 +1,3 @@
+# Spells: The Flow of Energy & Information
+
+Control, inject, or reshape data streams. See the [curriculum](../../docs/curriculum/spells-flow-of-energy-information/README.md) for outlines and exercises.

--- a/spellbooks/spirits-agi/README.md
+++ b/spellbooks/spirits-agi/README.md
@@ -1,0 +1,3 @@
+# Spirits: AGI
+
+Speculate on full sentience and alignment rituals. See the [curriculum](../../docs/curriculum/spirits-agi/README.md) for open questions.

--- a/spellbooks/sprites-llm-ai/README.md
+++ b/spellbooks/sprites-llm-ai/README.md
@@ -1,0 +1,3 @@
+# Sprites: LLM & AI
+
+Harness language-bound entities for reasoning and dialogue. See the [curriculum](../../docs/curriculum/sprites-llm-ai/README.md) for the full path.

--- a/spellbooks/symbolic-casting/README.md
+++ b/spellbooks/symbolic-casting/README.md
@@ -1,0 +1,3 @@
+# Symbolic Casting: Symbol cast & Q++
+
+Manipulate runes and quantum syntax. See the [curriculum](../../docs/curriculum/symbolic-casting/README.md) for further study.

--- a/spellbooks/weight/README.md
+++ b/spellbooks/weight/README.md
@@ -1,3 +1,0 @@
-# Book IV – Weight
-
-Responsibility and sacrifice.

--- a/test/chapters.test.ts
+++ b/test/chapters.test.ts
@@ -8,9 +8,9 @@ describe('Chapters API', () => {
     expect(Array.isArray(res.body)).toBe(true);
   });
 
-  test('GET /chapters/foundations returns markdown', async () => {
-    const res = await request(app).get('/chapters/foundations');
+  test('GET /chapters/open-source-development-for-wizards returns markdown', async () => {
+    const res = await request(app).get('/chapters/open-source-development-for-wizards');
     expect(res.statusCode).toBe(200);
-    expect(res.text).toContain('Book I');
+    expect(res.text).toContain('Open Source Development for Wizards');
   });
 });


### PR DESCRIPTION
## Summary
- restructure spellbooks to mirror curriculum chapters
- update chapters API test for new spellbook names
- reference curriculum from repository layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb46cbbf60832fb7da4f058ee0ed05